### PR TITLE
Specify input file, else tailwindcss falls back to default input

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "tailwindcss": "^3.1.2"
   },
   "scripts": {
-    "build": "npx tailwindcss -o build/tailwind.css"
+    "build": "npx tailwindcss -i ./css/tailwind.css -o ./build/tailwind.css"
   }
 }


### PR DESCRIPTION
👋🏼 Hello @digitalronin! Hope all is well with you!

I ran into this issue the other day so thought a PR and a comment will help resolve it!

Turns out, you need to specify an input file else `@tailwindcss/tailwindcss` uses a [fallback](https://github.com/tailwindlabs/tailwindcss/blob/0d064ea032373223922cb17a8b7ece3b3a23c720/src/cli.js#L679) to the standard configuration.

Hope that helps!